### PR TITLE
fix html string with non-wrapped text elements

### DIFF
--- a/html2pdfmake.js
+++ b/html2pdfmake.js
@@ -197,11 +197,13 @@ var html2pdfmake = function (html) {
     }
 
     function ParseHtml(cnt, htmlText) {
-        var html = $(htmlText.replace(/[\t\n]+/g, ''));
-        var p = CreateParagraph();
-        for (var i = 0; i < html.length; i++) {
-            ParseElement(cnt, html.get(i), p);
-        }
+      var p = CreateParagraph();
+      $('<div>').html(htmlText).contents().each(function(index, content) {
+          if(content.nodeName.toLowerCase() === '#text'){
+              content = $('<p>').append(content).get(0);
+          }
+          ParseElement(cnt, content, p);
+      });
     }
 
     function CreateParagraph() {


### PR DESCRIPTION
Hi @ymkins 

I realised that some of my HTML content elements have non-wrapped text elements through the generated HTML code of the rich text editor. I adjusted the parser and now it covers better html parsing:

```
Hello:
<ul>
<li>
a list item
</li>
</ul>
```

What do you think?
